### PR TITLE
Expmonoid

### DIFF
--- a/Lean4Axiomatic/ClassicalAlgebra/Monoid.lean
+++ b/Lean4Axiomatic/ClassicalAlgebra/Monoid.lean
@@ -1,4 +1,4 @@
-import Lean4Axiomatic.AbstractAlgebra.Substitutive
+import Lean4Axiomatic.AbstractAlgebra
 
 namespace Lean4Axiomatic.CA.Monoid
 
@@ -23,7 +23,7 @@ Operations for Monoid, namely the binary operation and identity element.
 class Ops (α : Type) :=
   binop : α → α → α
   ident : α
-export Ops (ident)
+export Ops (ident binop)
 
 /-- Enables the use of the `· * ·` operator for binop. -/
 local instance monoid_mul_op_inst {α : Type} [Monoid.Ops α] : Mul α := {
@@ -31,7 +31,7 @@ local instance monoid_mul_op_inst {α : Type} [Monoid.Ops α] : Mul α := {
 }
 
 /-- Properties of Monoid. -/
-class Props (α : Type) [evop : EqvOp α] [zz : Ops α] :=
+class Props (α : Type) [evop : EqvOp α] [Ops α] :=
   substL {x y z : α} : x ≃ y → x * z ≃ y * z
   substR {x y z : α} : x ≃ y → z * x ≃ z * y
   assoc {x y z : α} : (x * y) * z ≃ x * (y * z)
@@ -53,11 +53,16 @@ attribute [instance] Monoid.toProps
 variable {α : Type} [EqvOp α] [m : Monoid α]
 
 /-- Enables the use of `AA.substL`, `AA.substR`, etc. -/
-local instance monoid_subst_inst
-    : AA.Substitutive₂ (α := α) (· * ·) AA.tc (· ≃ ·) (· ≃ ·)
+instance monoid_subst_inst
+    : AA.Substitutive₂ (α := α) (β := α) (· * ·) AA.tc (· ≃ ·) (· ≃ ·)
     := {
   substitutiveL := { subst₂ := λ (_ : True) => substL }
   substitutiveR := { subst₂ := λ (_ : True) => substR }
+}
+
+/-- Enables the use of AA.assoc. -/
+instance monoid_assoc_inst : AA.Associative (α := α) (· * ·) := {
+    assoc := assoc
 }
 
 /--

--- a/Lean4Axiomatic/ClassicalAlgebra/Monoid.lean
+++ b/Lean4Axiomatic/ClassicalAlgebra/Monoid.lean
@@ -53,15 +53,15 @@ attribute [instance] Monoid.toProps
 variable {α : Type} [EqvOp α] [m : Monoid α]
 
 /-- Enables the use of `AA.substL`, `AA.substR`, etc. -/
-instance monoid_subst_inst
-    : AA.Substitutive₂ (α := α) (β := α) (· * ·) AA.tc (· ≃ ·) (· ≃ ·)
+scoped instance monoid_subst_inst
+    : AA.Substitutive₂ (α := α) (· * ·) AA.tc (· ≃ ·) (· ≃ ·)
     := {
   substitutiveL := { subst₂ := λ (_ : True) => substL }
   substitutiveR := { subst₂ := λ (_ : True) => substR }
 }
 
 /-- Enables the use of AA.assoc. -/
-instance monoid_assoc_inst : AA.Associative (α := α) (· * ·) := {
+scoped instance monoid_assoc_inst : AA.Associative (α := α) (· * ·) := {
     assoc := assoc
 }
 

--- a/Lean4Axiomatic/ClassicalAlgebra/Monoid.lean
+++ b/Lean4Axiomatic/ClassicalAlgebra/Monoid.lean
@@ -31,7 +31,7 @@ local instance monoid_mul_op_inst {α : Type} [Monoid.Ops α] : Mul α := {
 }
 
 /-- Properties of Monoid. -/
-class Props (α : Type) [evop : EqvOp α] [Ops α] :=
+class Props (α : Type) [EqvOp α] [Ops α] :=
   substL {x y z : α} : x ≃ y → x * z ≃ y * z
   substR {x y z : α} : x ≃ y → z * x ≃ z * y
   assoc {x y z : α} : (x * y) * z ≃ x * (y * z)

--- a/Lean4Axiomatic/Natural.lean
+++ b/Lean4Axiomatic/Natural.lean
@@ -24,7 +24,7 @@ class Natural (ℕ : semiOutParam Type) :=
   toOrder : Order ℕ
   toCompare : Compare ℕ
   toMultiplication : Multiplication ℕ
-  toExponentiation : Exponentiation ℕ (α := ℕ) (· * ·)
+  toExponentiation : Exponentiation ℕ (α := ℕ)
 
 attribute [instance] Natural.toAddition
 attribute [instance] Natural.toCompare

--- a/Lean4Axiomatic/Natural/Addition.lean
+++ b/Lean4Axiomatic/Natural/Addition.lean
@@ -303,7 +303,7 @@ local instance add_monoid_ops :  CA.Monoid.Ops ℕ := {
   ident := 0
 }
 
-def add_monoid_props : CA.Monoid.Props (α := ℕ) (zz := add_monoid_ops) :=
+def add_monoid_props : CA.Monoid.Props (α := ℕ) :=
   let subst_addL {n₁ n₂ m : ℕ} : n₁ ≃ n₂ → n₁ + m ≃ n₂ + m := AA.substL;
   let subst_addR {n₁ n₂ m : ℕ} : n₁ ≃ n₂ → m + n₁ ≃ m + n₂ := AA.substR;
 {

--- a/Lean4Axiomatic/Natural/Exponentiation.lean
+++ b/Lean4Axiomatic/Natural/Exponentiation.lean
@@ -60,7 +60,7 @@ export Exponentiation.Props (pow_step pow_zero)
 /-- All exponentiation axioms. -/
 class Exponentiation
     (ℕ : semiOutParam Type) {α : Type}
-    [Core ℕ] [Addition ℕ] [Multiplication ℕ] [eqvop : EqvOp α]
+    [Core ℕ] [Addition ℕ] [Multiplication ℕ] [EqvOp α]
     [CA.Monoid.Monoid α]
     :=
   toOps : Exponentiation.Ops α ℕ
@@ -367,7 +367,7 @@ multiplication, then that's just the original number.
 theorem pow_one {x : α} : x^1 ≃ x := calc
   _ = x^1         := rfl
   _ ≃ x^(step 0)  := pow_substR literal_step
-  _ ≃ x^(0) * x := pow_step
+  _ ≃ x^0 * x     := pow_step
   _ ≃ 1 * x       := AA.substL pow_zero
   _ ≃ x           := identL
 

--- a/Lean4Axiomatic/Natural/Exponentiation.lean
+++ b/Lean4Axiomatic/Natural/Exponentiation.lean
@@ -273,7 +273,7 @@ theorem pow_inputs_for_output_zero
   case zero =>
     intro (_ : x^(0:ℕ) ≃ 0)
     show x ≃ 0 ∧ 0 ≄ 0
-    have : (1 : α) ≃ 0 := calc
+    have : (1:α) ≃ 0 := calc
       _ ≃ 1   := Rel.refl
       _ ≃ x^0 := Rel.symm pow_zero
       _ ≃ 0   := ‹x^(0:ℕ) ≃ 0›
@@ -367,7 +367,7 @@ multiplication, then that's just the original number.
 theorem pow_one {x : α} : x^1 ≃ x := calc
   _ = x^1         := rfl
   _ ≃ x^(step 0)  := pow_substR literal_step
-  _ ≃ x^(0:ℕ) * x := pow_step
+  _ ≃ x^(0) * x := pow_step
   _ ≃ 1 * x       := AA.substL pow_zero
   _ ≃ x           := identL
 

--- a/Lean4Axiomatic/Natural/Exponentiation.lean
+++ b/Lean4Axiomatic/Natural/Exponentiation.lean
@@ -11,6 +11,8 @@ open Logic (AP)
 open Relation.Equivalence (EqvOp)
 open Signed (Positive)
 
+open scoped CA.Monoid
+
 /-!
 ## Axioms
 -/
@@ -33,17 +35,25 @@ instance (priority := default+1) pow_inst
   pow := Exponentiation.Ops._pow
 }
 
+/-- Enables the use of `· * ·` syntax for `α`'s multiplication function. -/
+local instance mul_inst [EqvOp α] [CA.Monoid.Monoid α] : Mul α := {
+  mul := binop
+}
+
+instance ofNatIdent [EqvOp α] [CA.Monoid.Monoid α] : OfNat α 1 := {
+  ofNat := ident
+}
+
 /-- Properties of exponentiation for a monoid type α to a natural number. -/
 class Exponentiation.Props
     {α : Type} {ℕ : outParam Type}
     [Core ℕ] [Addition ℕ] [Multiplication ℕ] [EqvOp α] [Ops α ℕ]
-    [isMonoid : CA.Monoid.Monoid α]
+    [CA.Monoid.Monoid α]
     :=
-  /- TODO: replace requirement of being a monoid with being a commutative ring. -/
-  /-- Any number raised to the power zero is the multiplicative identity of α. -/
-  pow_zero {x : α} : x ^ (0:ℕ) ≃ ident
+  /-- Any number raised to the power zero is the monoid identity of α. -/
+  pow_zero {x : α} : x ^ (0:ℕ) ≃ 1
   /-- Adding one to the exponent multiplies the result by the base. -/
-  pow_step {x : α} {n : ℕ} : x ^ step n ≃ binop (x ^ n) x
+  pow_step {x : α} {n : ℕ} : x ^ step n ≃ (x ^ n) * x
 
 export Exponentiation.Props (pow_step pow_zero)
 
@@ -51,7 +61,7 @@ export Exponentiation.Props (pow_step pow_zero)
 class Exponentiation
     (ℕ : semiOutParam Type) {α : Type}
     [Core ℕ] [Addition ℕ] [Multiplication ℕ] [eqvop : EqvOp α]
-    [isMonoid : CA.Monoid.Monoid α]
+    [CA.Monoid.Monoid α]
     :=
   toOps : Exponentiation.Ops α ℕ
   toProps : Exponentiation.Props (α := α)
@@ -70,15 +80,9 @@ section general
 /-! ### General properties for any base type -/
 
 variable
-  {α : Type} [EqvOp α] [isMonoid : CA.Monoid.Monoid α]
-  [Exponentiation ℕ (α := α)]
+  {α : Type} [EqvOp α] [CA.Monoid.Monoid α] [Exponentiation ℕ (α := α)]
 
-/-- Enables the use of `· * ·` syntax for `α`'s multiplication function. -/
-local instance mul_inst [Exponentiation ℕ (α := α)] : Mul α := {
-  mul := binop
-}
-
-/-
+/--
 Equivalent values can be substituted for the base (left operand) in an
 exponentiation.
 
@@ -97,7 +101,7 @@ theorem pow_substL {x₁ x₂ : α} {m : ℕ} : x₁ ≃ x₂ → x₁ ^ m ≃ x
     show x₁ ^ 0 ≃ x₂ ^ 0
     calc
       _ ≃ x₁ ^ 0 := Rel.refl
-      _ ≃ ident  := pow_zero
+      _ ≃ 1      := pow_zero
       _ ≃ x₂ ^ 0 := Rel.symm pow_zero
   case step =>
     intro (m' : ℕ) (ih : x₁ ^ m' ≃ x₂ ^ m')
@@ -175,7 +179,7 @@ theorem pow_compatL_add
     calc
       _ ≃ x^(0 + m)     := Rel.refl
       _ ≃ x^m           := pow_substR AA.identL
-      _ ≃ ident * x^m   := Rel.symm identL
+      _ ≃ 1 * x^m       := Rel.symm identL
       _ ≃ x^(0:ℕ) * x^m := AA.substL (Rel.symm pow_zero)
   case step =>
     intro n' (ih : x^(n' + m) ≃ x^n' * x^m)
@@ -207,7 +211,7 @@ theorem pow_flatten
     show (x^n)^0 ≃ x^(n * 0)
     calc
       _ ≃ (x^n)^0   := Rel.refl
-      _ ≃ ident     := pow_zero
+      _ ≃ 1         := pow_zero
       _ ≃ x^0       := Rel.symm pow_zero
       _ ≃ x^(n * 0) := pow_substR (Rel.symm mul_zero)
   case step =>
@@ -237,10 +241,10 @@ theorem pow_distribR_mul
     show (x * y)^0 ≃ x^0 * y^0
     calc
       _ ≃ (x * y)^0 := Rel.refl
-      _ ≃ ident         := pow_zero
-      _ ≃ ident * ident := Rel.symm identR
-      _ ≃ x^0 * ident   := AA.substL (Rel.symm pow_zero)
-      _ ≃ x^0 * y^0     := AA.substR (Rel.symm pow_zero)
+      _ ≃ 1         := pow_zero
+      _ ≃ 1 * 1     := Rel.symm identR
+      _ ≃ x^0 * 1   := AA.substL (Rel.symm pow_zero)
+      _ ≃ x^0 * y^0 := AA.substR (Rel.symm pow_zero)
   case step =>
     intro n' (ih : (x * y)^n' ≃ x^n' * y^n')
     show (x * y)^(step n') ≃ x^(step n') * y^(step n')
@@ -262,18 +266,18 @@ base must be zero. By definition, exponentiation gives one if the exponent is
 zero; thus it must be nonzero in this case.
 -/
 theorem pow_inputs_for_output_zero
-    [OfNat α 0] [AP ((ident:α) ≄ 0)] [AA.ZeroProduct (α := α) (· * ·)]
+    [OfNat α 0] [AP ((1:α) ≄ 0)] [AA.ZeroProduct (α := α) (· * ·)]
     {x : α} {n : ℕ} : x^n ≃ 0 → x ≃ 0 ∧ n ≄ 0
     := by
   apply ind_on (motive := λ m => x^m ≃ 0 → x ≃ 0 ∧ m ≄ 0) n
   case zero =>
     intro (_ : x^(0:ℕ) ≃ 0)
     show x ≃ 0 ∧ 0 ≄ 0
-    have : (ident : α) ≃ 0 := calc
-      _ ≃ ident := Rel.refl
-      _ ≃ x^0   := Rel.symm pow_zero
-      _ ≃ 0     := ‹x^(0:ℕ) ≃ 0›
-    exact absurd ‹(ident:α) ≃ 0› ‹AP ((ident:α) ≄ 0)›.ev
+    have : (1 : α) ≃ 0 := calc
+      _ ≃ 1   := Rel.refl
+      _ ≃ x^0 := Rel.symm pow_zero
+      _ ≃ 0   := ‹x^(0:ℕ) ≃ 0›
+    exact absurd ‹(1:α) ≃ 0› ‹AP ((1:α) ≄ 0)›.ev
   case step =>
     intro (n' : ℕ) (ih : x^n' ≃ 0 → x ≃ 0 ∧ n' ≄ 0) (_ : x^(step n') ≃ 0)
     show x ≃ 0 ∧ step n' ≄ 0
@@ -299,7 +303,7 @@ one factor (because the exponent is nonzero), and since that factor is zero,
 the result is zero by absorption.
 -/
 theorem pow_eqv_zero
-    [OfNat α 0] [AP ((ident:α) ≄ 0)] [AA.ZeroProduct (α := α) (· * ·)]
+    [OfNat α 0] [AP ((1:α) ≄ 0)] [AA.ZeroProduct (α := α) (· * ·)]
     [AA.Absorbing (0:α) (· * ·)]
     {x : α} {n : ℕ} : x^n ≃ 0 ↔ x ≃ 0 ∧ n ≄ 0
     := by
@@ -323,13 +327,13 @@ theorem pow_eqv_zero
 Raising a nonzero number to any natural number power always gives a nonzero
 result.
 
-**Property intuition**: The empty product is `ident` (raising to the zero power),
+**Property intuition**: The empty product is `1` (raising to the zero power),
 and any product of nonzero numbers is always nonzero (higher powers).
 
 **Proof intuition**: Follows from `pow_inputs_for_output_zero` by logic alone.
 -/
 theorem pow_preserves_nonzero_base
-    [OfNat α 0] [AP ((ident:α) ≄ 0)] [AA.ZeroProduct (α := α) (· * ·)]
+    [OfNat α 0] [AP ((1:α) ≄ 0)] [AA.ZeroProduct (α := α) (· * ·)]
     {x : α} {n : ℕ} : x ≄ 0 → x^n ≄ 0
     := by
   intro (_ : x ≄ 0)
@@ -347,7 +351,7 @@ Instance version of `pow_preserves_nonzero_base`.
 Enables clean syntax when dividing by an exponentiation expression.
 -/
 instance pow_preserves_nonzero_base_inst
-    [OfNat α 0] [AP ((ident:α) ≄ 0)] [AA.ZeroProduct (α := α) (· * ·)]
+    [OfNat α 0] [AP ((1:α) ≄ 0)] [AA.ZeroProduct (α := α) (· * ·)]
     {x : α} {n : ℕ} [AP (x ≄ 0)] : AP (x^n ≄ 0)
     :=
   ‹AP (x ≄ 0)›.map pow_preserves_nonzero_base
@@ -364,8 +368,8 @@ theorem pow_one {x : α} : x^1 ≃ x := calc
   _ = x^1         := rfl
   _ ≃ x^(step 0)  := pow_substR literal_step
   _ ≃ x^(0:ℕ) * x := pow_step
-  _ ≃ ident * x   := AA.substL pow_zero
-  _ ≃ x           := isMonoid.toProps.identL
+  _ ≃ 1 * x       := AA.substL pow_zero
+  _ ≃ x           := identL
 
 end general
 

--- a/Lean4Axiomatic/Natural/Exponentiation.lean
+++ b/Lean4Axiomatic/Natural/Exponentiation.lean
@@ -47,8 +47,7 @@ instance ofNatIdent [EqvOp α] [CA.Monoid.Monoid α] : OfNat α 1 := {
 /-- Properties of exponentiation for a monoid type α to a natural number. -/
 class Exponentiation.Props
     {α : Type} {ℕ : outParam Type}
-    [Core ℕ] [Addition ℕ] [Multiplication ℕ] [EqvOp α] [Ops α ℕ]
-    [CA.Monoid.Monoid α]
+    [Core ℕ] [Addition ℕ] [Multiplication ℕ] [EqvOp α] [Ops α ℕ] [CA.Monoid.Monoid α]
     :=
   /-- Any number raised to the power zero is the monoid identity of α. -/
   pow_zero {x : α} : x ^ (0:ℕ) ≃ 1

--- a/Lean4Axiomatic/Natural/Exponentiation.lean
+++ b/Lean4Axiomatic/Natural/Exponentiation.lean
@@ -47,7 +47,8 @@ instance ofNatIdent [EqvOp α] [CA.Monoid.Monoid α] : OfNat α 1 := {
 /-- Properties of exponentiation for a monoid type α to a natural number. -/
 class Exponentiation.Props
     {α : Type} {ℕ : outParam Type}
-    [Core ℕ] [Addition ℕ] [Multiplication ℕ] [EqvOp α] [Ops α ℕ] [CA.Monoid.Monoid α]
+    [Core ℕ] [Addition ℕ] [Multiplication ℕ] [EqvOp α] [Ops α ℕ]
+    [CA.Monoid.Monoid α]
     :=
   /-- Any number raised to the power zero is the monoid identity of α. -/
   pow_zero {x : α} : x ^ (0:ℕ) ≃ 1

--- a/Lean4Axiomatic/Natural/Impl/Generic/Exponentiation.lean
+++ b/Lean4Axiomatic/Natural/Impl/Generic/Exponentiation.lean
@@ -11,7 +11,7 @@ open Lean4Axiomatic.CA.Monoid (ident binop identL identR)
 
 variable
   {ℕ : Type} [Core ℕ] [Induction.{1} ℕ] [Addition ℕ] [Multiplication ℕ]
-  {α : Type} [EqvOp α] [OfNat α 1] [CA.Monoid.Monoid α]
+  {α : Type} [EqvOp α] [CA.Monoid.Monoid α]
 
 /-- Enables the use of `· * ·` syntax. -/
 local instance mul_inst : Mul α := {
@@ -24,7 +24,7 @@ Raise a value to a natural number power.
 **Definition intuition**: Performs the correct number of multiplications using
 recursion.
 -/
-def _pow (x : α) (n : ℕ) : α := rec_on n ident (· * x)
+def _pow (x : α) (n : ℕ) : α := rec_on n 1 (· * x)
 
 local instance exponentiation_ops : Exponentiation.Ops α ℕ := {
   _pow := _pow
@@ -36,10 +36,10 @@ Anything to the zero power is one.
 **Property and proof intuition**: This corresponds to the base case in the
 recursive definition of `_pow`.
 -/
-theorem pow_zero {x : α} : x ^ (0:ℕ) ≃ ident := calc
+theorem pow_zero {x : α} : x ^ (0:ℕ) ≃ 1 := calc
   _ ≃ x ^ (0:ℕ)              := Rel.refl
-  _ = rec_on 0 ident (· * x) := rfl
-  _ = ident                  := rec_on_zero
+  _ = rec_on 0 1 (· * x) := rfl
+  _ = 1                  := rec_on_zero
 
 /--
 Adding one to the exponent multiplies the result by the base.
@@ -49,8 +49,8 @@ definition of `_pow`.
 -/
 theorem pow_step {x : α} {n : ℕ} : x ^ step n ≃ x ^ n * x := calc
   _ ≃ x ^ step n                    := Rel.refl
-  _ = rec_on (step n) ident (· * x) := rfl
-  _ = (rec_on n ident (· * x)) * x  := rec_on_step
+  _ = rec_on (step n) 1 (· * x) := rfl
+  _ = (rec_on n 1 (· * x)) * x  := rec_on_step
   _ = x ^ n * x                     := rfl
 
 def exponentiation_props : Exponentiation.Props (α := α) := {

--- a/Lean4Axiomatic/Natural/Impl/Generic/Exponentiation.lean
+++ b/Lean4Axiomatic/Natural/Impl/Generic/Exponentiation.lean
@@ -37,7 +37,7 @@ Anything to the zero power is one.
 recursive definition of `_pow`.
 -/
 theorem pow_zero {x : α} : x ^ (0:ℕ) ≃ 1 := calc
-  _ ≃ x ^ (0:ℕ)              := Rel.refl
+  _ ≃ x ^ (0:ℕ)         := Rel.refl
   _ = rec_on 0 1 (· * x) := rfl
   _ = 1                  := rec_on_zero
 
@@ -48,10 +48,10 @@ Adding one to the exponent multiplies the result by the base.
 definition of `_pow`.
 -/
 theorem pow_step {x : α} {n : ℕ} : x ^ step n ≃ x ^ n * x := calc
-  _ ≃ x ^ step n                    := Rel.refl
+  _ ≃ x ^ step n                := Rel.refl
   _ = rec_on (step n) 1 (· * x) := rfl
   _ = (rec_on n 1 (· * x)) * x  := rec_on_step
-  _ = x ^ n * x                     := rfl
+  _ = x ^ n * x                 := rfl
 
 def exponentiation_props : Exponentiation.Props (α := α) := {
   pow_zero := pow_zero

--- a/Lean4Axiomatic/Natural/Impl/Generic/Exponentiation.lean
+++ b/Lean4Axiomatic/Natural/Impl/Generic/Exponentiation.lean
@@ -7,10 +7,16 @@ import Lean4Axiomatic.Natural.Exponentiation
 namespace Lean4Axiomatic.Natural.Impl.Generic
 
 open Relation.Equivalence (EqvOp)
+open Lean4Axiomatic.CA.Monoid (ident binop identL identR)
 
 variable
   {ℕ : Type} [Core ℕ] [Induction.{1} ℕ] [Addition ℕ] [Multiplication ℕ]
-  {α : Type} [EqvOp α] [OfNat α 1] [Mul α]
+  {α : Type} [EqvOp α] [OfNat α 1] [CA.Monoid.Monoid α]
+
+/-- Enables the use of `· * ·` syntax. -/
+local instance mul_inst : Mul α := {
+  mul := binop
+}
 
 /--
 Raise a value to a natural number power.
@@ -18,7 +24,7 @@ Raise a value to a natural number power.
 **Definition intuition**: Performs the correct number of multiplications using
 recursion.
 -/
-def _pow (x : α) (n : ℕ) : α := rec_on n 1 (· * x)
+def _pow (x : α) (n : ℕ) : α := rec_on n ident (· * x)
 
 local instance exponentiation_ops : Exponentiation.Ops α ℕ := {
   _pow := _pow
@@ -30,10 +36,10 @@ Anything to the zero power is one.
 **Property and proof intuition**: This corresponds to the base case in the
 recursive definition of `_pow`.
 -/
-theorem pow_zero {x : α} : x ^ (0:ℕ) ≃ 1 := calc
-  _ ≃ x ^ (0:ℕ)          := Rel.refl
-  _ = rec_on 0 1 (· * x) := rfl
-  _ = 1                  := rec_on_zero
+theorem pow_zero {x : α} : x ^ (0:ℕ) ≃ ident := calc
+  _ ≃ x ^ (0:ℕ)              := Rel.refl
+  _ = rec_on 0 ident (· * x) := rfl
+  _ = ident                  := rec_on_zero
 
 /--
 Adding one to the exponent multiplies the result by the base.
@@ -42,17 +48,17 @@ Adding one to the exponent multiplies the result by the base.
 definition of `_pow`.
 -/
 theorem pow_step {x : α} {n : ℕ} : x ^ step n ≃ x ^ n * x := calc
-  _ ≃ x ^ step n                := Rel.refl
-  _ = rec_on (step n) 1 (· * x) := rfl
-  _ = (rec_on n 1 (· * x)) * x  := rec_on_step
-  _ = x ^ n * x                 := rfl
+  _ ≃ x ^ step n                    := Rel.refl
+  _ = rec_on (step n) ident (· * x) := rfl
+  _ = (rec_on n ident (· * x)) * x  := rec_on_step
+  _ = x ^ n * x                     := rfl
 
-def exponentiation_props : Exponentiation.Props (α := α) (· * ·) := {
+def exponentiation_props : Exponentiation.Props (α := α) := {
   pow_zero := pow_zero
   pow_step := pow_step
 }
 
-def exponentiation : Exponentiation ℕ (α := α) (· * ·) := {
+def exponentiation : Exponentiation ℕ (α := α):= {
   toOps := exponentiation_ops
   toProps := exponentiation_props
 }

--- a/Lean4Axiomatic/Natural/Multiplication.lean
+++ b/Lean4Axiomatic/Natural/Multiplication.lean
@@ -1,6 +1,7 @@
 import Lean4Axiomatic.AbstractAlgebra
 import Lean4Axiomatic.Logic
 import Lean4Axiomatic.Natural.Order
+import Lean4Axiomatic.ClassicalAlgebra.Monoid
 
 /-!
 # Natural number multiplication
@@ -507,5 +508,47 @@ theorem sqrt1 {n : ℕ} : n * n ≃ 1 ↔ n ≃ 1 := by
     show n * n ≃ 1
     have : n * n ≃ 1 := factors_eqv_1.mpr (And.intro ‹n ≃ 1› ‹n ≃ 1›)
     exact this
+
+local instance mul_monoid_ops :  CA.Monoid.Ops ℕ := {
+  binop := (· * ·)
+  ident := 1
+}
+
+def mul_monoid_props : CA.Monoid.Props (α := ℕ) :=
+{
+  substL  := AA.substL
+  substR  := AA.substR
+  assoc   := mul_associative.assoc
+  identL  := AA.identL
+  identR  := AA.identR
+}
+
+/--
+Naturals numbers with multiplication form a monoid.  This allow us to avoid
+reproving basic facts about naturals that are true of all monoids.
+TODO: instead of monoid, show the naturals form a commutative ring.
+-/
+instance mul_monoid : CA.Monoid.Monoid (α := ℕ) := {
+  toOps   := mul_monoid_ops
+  toProps := mul_monoid_props
+}
+
+/--
+The natural 1 is not equal to 0.
+-/
+theorem one_neqv_zero : (1 : ℕ) ≄ 0 := by
+  intro (_ : (1 : ℕ) ≃ 0)
+  show False
+  have : (1 : ℕ) ≃ (0 : ℕ) := ‹(1 : ℕ) ≃ 0›
+  have : Natural.step (0 : ℕ) ≃ 0 :=
+    Rel.trans (Rel.symm Natural.literal_step) ‹(1 : ℕ) ≃ 0›
+  exact absurd ‹Natural.step (0 : ℕ) ≃ 0› Natural.step_neqv_zero
+
+/--
+The multiplicative identity for naturals is not the same as 0.
+-/
+theorem mul_ident_not_zero : mul_monoid.toOps.ident ≄ 0 := by
+  show mul_monoid.toOps.ident ≄ 0
+  exact one_neqv_zero
 
 end Lean4Axiomatic.Natural

--- a/Lean4Axiomatic/Natural/Multiplication.lean
+++ b/Lean4Axiomatic/Natural/Multiplication.lean
@@ -514,8 +514,7 @@ local instance mul_monoid_ops :  CA.Monoid.Ops ℕ := {
   ident := 1
 }
 
-def mul_monoid_props : CA.Monoid.Props (α := ℕ) :=
-{
+def mul_monoid_props : CA.Monoid.Props (α := ℕ) := {
   substL  := AA.substL
   substR  := AA.substR
   assoc   := mul_associative.assoc
@@ -542,12 +541,5 @@ theorem one_neqv_zero : (1 : ℕ) ≄ 0 := by
   have : Natural.step (0 : ℕ) ≃ 0 :=
     Rel.trans (Rel.symm Natural.literal_step) ‹(1 : ℕ) ≃ 0›
   exact absurd ‹Natural.step (0 : ℕ) ≃ 0› Natural.step_neqv_zero
-
-/--
-The multiplicative identity for naturals is not the same as 0.
--/
-theorem mul_ident_not_zero : mul_monoid.toOps.ident ≄ 0 := by
-  show mul_monoid.toOps.ident ≄ 0
-  exact one_neqv_zero
 
 end Lean4Axiomatic.Natural

--- a/Lean4Axiomatic/Natural/Multiplication.lean
+++ b/Lean4Axiomatic/Natural/Multiplication.lean
@@ -526,7 +526,6 @@ def mul_monoid_props : CA.Monoid.Props (α := ℕ) :=
 /--
 Naturals numbers with multiplication form a monoid.  This allow us to avoid
 reproving basic facts about naturals that are true of all monoids.
-TODO: instead of monoid, show the naturals form a commutative ring.
 -/
 instance mul_monoid : CA.Monoid.Monoid (α := ℕ) := {
   toOps   := mul_monoid_ops

--- a/Lean4Axiomatic/Rational.lean
+++ b/Lean4Axiomatic/Rational.lean
@@ -20,7 +20,7 @@ class Rational
   toCore : Rational.Core (ℤ := ℤ) ℚ
   toAddition : Rational.Addition ℚ
   toMultiplication : Rational.Multiplication ℚ
-  toNaturalExponentiation : Natural.Exponentiation ℕ (α := ℚ) (· * ·)
+  toNaturalExponentiation : Natural.Exponentiation ℕ (α := ℚ)
   toNegation : Rational.Negation ℚ
   toSubtraction : Rational.Subtraction ℚ
   toReciprocation : Rational.Reciprocation ℚ

--- a/Lean4Axiomatic/Rational/Exponentiation.lean
+++ b/Lean4Axiomatic/Rational/Exponentiation.lean
@@ -25,7 +25,7 @@ variable
   {ℚ : Type}
     [Core (ℤ := ℤ) ℚ] [Addition ℚ] [Multiplication ℚ]
     [Negation ℚ] [Subtraction ℚ] [Reciprocation ℚ] [Division ℚ]
-    [Sign ℚ] [Order ℚ] [Metric ℚ] [Natural.Exponentiation ℕ (α := ℚ) (· * ·)]
+    [Sign ℚ] [Order ℚ] [Metric ℚ] [Natural.Exponentiation ℕ (α := ℚ)]
 
 /--
 Raising two ordered, nonnegative values to the same natural number power
@@ -237,7 +237,7 @@ infixr:80 " ^ " => Exponentiation.Ops._pow
 class Exponentiation.Props
     {ℕ ℤ : Type} [Natural ℕ] [Integer (ℕ := ℕ) ℤ]
     (ℚ : Type) [Core (ℤ := ℤ) ℚ] [Addition ℚ] [Multiplication ℚ]
-    [Reciprocation ℚ] [Division ℚ] [Natural.Exponentiation ℕ (α := ℚ) (· * ·)]
+    [Reciprocation ℚ] [Division ℚ] [Natural.Exponentiation ℕ (α := ℚ)]
     [Negation ℚ] [Sign ℚ] [Ops ℚ ℤ]
     :=
   /--
@@ -268,7 +268,7 @@ export Exponentiation.Props (pow_diff pow_substR)
 class Exponentiation
     {ℕ ℤ : Type} [Natural ℕ] [Integer (ℕ := ℕ) ℤ]
     (ℚ : Type) [Core (ℤ := ℤ) ℚ] [Addition ℚ] [Multiplication ℚ]
-    [Reciprocation ℚ] [Division ℚ] [Natural.Exponentiation ℕ (α := ℚ) (· * ·)]
+    [Reciprocation ℚ] [Division ℚ] [Natural.Exponentiation ℕ (α := ℚ)]
     [Negation ℚ] [Sign ℚ]
     :=
   toOps : Exponentiation.Ops ℚ ℤ
@@ -284,7 +284,7 @@ variable
   {ℚ : Type}
     [Core (ℤ := ℤ) ℚ] [Addition ℚ] [Multiplication ℚ]
     [Negation ℚ] [Reciprocation ℚ] [Division ℚ] [Sign ℚ]
-    [Natural.Exponentiation ℕ (α := ℚ) (· * ·)] [Exponentiation ℚ]
+    [Natural.Exponentiation ℕ (α := ℚ) ] [Exponentiation ℚ]
 
 /--
 Rational number exponentiation to an integer respects equivalence of the base

--- a/Lean4Axiomatic/Rational/Impl/Generic/Exponentiation.lean
+++ b/Lean4Axiomatic/Rational/Impl/Generic/Exponentiation.lean
@@ -12,7 +12,7 @@ variable
   {ℚ : Type}
     [Core (ℤ := ℤ) ℚ] [Addition ℚ] [Multiplication ℚ] [Negation ℚ]
     [Reciprocation ℚ] [Division ℚ] [Sign ℚ]
-    [Natural.Exponentiation ℕ (α := ℚ) (· * ·)]
+    [Natural.Exponentiation ℕ (α := ℚ)]
 
 /--
 Raises a nonzero rational number to an integer power, represented as the

--- a/Lean4Axiomatic/Rational/Multiplication.lean
+++ b/Lean4Axiomatic/Rational/Multiplication.lean
@@ -231,8 +231,4 @@ instance mul_monoid : CA.Monoid.Monoid (α := ℚ) := {
   toProps := mul_monoid_props
 }
 
-instance : AP ((mul_monoid.toOps.ident) ≄ (0 : ℚ)) := by
-  have mul_ident_not_zero : mul_monoid.toOps.ident ≄ (0 : ℚ) := nonzero_one
-  exact AP.mk mul_ident_not_zero
-
 end Lean4Axiomatic.Rational

--- a/Lean4Axiomatic/Rational/Multiplication.lean
+++ b/Lean4Axiomatic/Rational/Multiplication.lean
@@ -1,5 +1,8 @@
 import Lean4Axiomatic.AbstractAlgebra
+import Lean4Axiomatic.ClassicalAlgebra.Monoid
 import Lean4Axiomatic.Rational.Addition
+
+open Lean4Axiomatic.Logic (AP)
 
 /-! # Rational numbers: multiplication -/
 
@@ -204,5 +207,32 @@ integer square roots of unity are also rational square roots of unity.
 -/
 instance sqrt1_one : Sqrt1 (1 : ℚ) :=
   from_integer_preserves_sqrt1.mpr Integer.sqrt1_one
+
+local instance mul_monoid_ops :  CA.Monoid.Ops ℚ := {
+  binop := (· * ·)
+  ident := 1
+}
+
+def mul_monoid_props : CA.Monoid.Props (α := ℚ) :=
+{
+  substL  := AA.substL
+  substR  := AA.substR
+  assoc   := mul_assoc
+  identL  := AA.identL
+  identR  := AA.identR
+}
+
+/-
+  Rationals with multiplication form a monoid.
+  TODO: Show rationals form a ring.
+-/
+instance mul_monoid : CA.Monoid.Monoid (α := ℚ) := {
+  toOps   := mul_monoid_ops
+  toProps := mul_monoid_props
+}
+
+instance : AP ((mul_monoid.toOps.ident) ≄ (0 : ℚ)) := by
+  have mul_ident_not_zero : mul_monoid.toOps.ident ≄ (0 : ℚ) := nonzero_one
+  exact AP.mk mul_ident_not_zero
 
 end Lean4Axiomatic.Rational

--- a/Lean4Axiomatic/Rational/Reciprocation.lean
+++ b/Lean4Axiomatic/Rational/Reciprocation.lean
@@ -38,12 +38,11 @@ def of_scientific
     (mantissa : Nat) (exponentIsNegative : Bool) (decimalExponent : Nat) : ℚ
     :=
   let naturalMantissa : ℕ := OfNat.ofNat mantissa
-  let naturalDecimalExponent : ℕ := OfNat.ofNat decimalExponent
+  let naturalDecimalExponent : ℕ := OfNat.ofNat decimalExponent 
   let powTen := (10:ℕ) ^ naturalDecimalExponent
 
-  have : Natural.step 0 ≄ 0 := Natural.step_neqv_zero
-  have : (1:ℕ) ≄ 0 := AA.neqv_substL (Rel.symm Natural.literal_step) this
-  have : AP ((1:ℕ) ≄ 0) := AP.mk this
+  have : Natural.mul_monoid.toOps.ident ≄ 0 := Natural.one_neqv_zero
+  have : AP (Natural.mul_monoid.toOps.ident ≄ 0) := AP.mk this
 
   have : Natural.step 9 ≄ 0 := Natural.step_neqv_zero
   have : (10:ℕ) ≄ 0 := AA.neqv_substL (Rel.symm Natural.literal_step) this

--- a/Lean4Axiomatic/Rational/Reciprocation.lean
+++ b/Lean4Axiomatic/Rational/Reciprocation.lean
@@ -38,11 +38,11 @@ def of_scientific
     (mantissa : Nat) (exponentIsNegative : Bool) (decimalExponent : Nat) : ℚ
     :=
   let naturalMantissa : ℕ := OfNat.ofNat mantissa
-  let naturalDecimalExponent : ℕ := OfNat.ofNat decimalExponent 
+  let naturalDecimalExponent : ℕ := OfNat.ofNat decimalExponent
   let powTen := (10:ℕ) ^ naturalDecimalExponent
 
-  have : Natural.mul_monoid.toOps.ident ≄ 0 := Natural.one_neqv_zero
-  have : AP (Natural.mul_monoid.toOps.ident ≄ 0) := AP.mk this
+  have : (1:ℕ) ≄ 0 := Natural.one_neqv_zero
+  have : AP ((1:ℕ) ≄ 0) := AP.mk this
 
   have : Natural.step 9 ≄ 0 := Natural.step_neqv_zero
   have : (10:ℕ) ≄ 0 := AA.neqv_substL (Rel.symm Natural.literal_step) this


### PR DESCRIPTION
Use a monoid for the underlying type during exponentiation to a natural number.  